### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/project/projectboard/domain/Article.java
+++ b/src/main/java/com/project/projectboard/domain/Article.java
@@ -38,7 +38,7 @@ public class Article extends AuditingFields {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
-    
+
     private Article(String title, String content, String hashtag) {
         this.title = title;
         this.content = content;

--- a/src/main/java/com/project/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/project/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,9 @@ package com.project.projectboard.repository;
 
 import com.project.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/project/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/project/projectboard/repository/ArticleRepository.java
@@ -2,7 +2,10 @@ package com.project.projectboard.repository;
 
 import com.project.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/src/test/java/com/project/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/project/projectboard/controller/DataRestTest.java
@@ -1,0 +1,77 @@
+package com.project.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.awt.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+//@WebMvcTest
+@DisplayName("Data REST API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Test
+    @DisplayName("[api] 게시글 전체 리스트 조회")
+    void given_whenRequesting_thenReturnsArticlesJsonResponse() throws Exception {
+        //given
+
+        //when&then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @Test
+    @DisplayName("[api] 단건 게시글 댓글 리스트 조회")
+    void given_whenRequestingArticleCommentsFromArticle_thenReturnsArticlesCommentsJsonResponse() throws Exception {
+        //given
+
+        //when&then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @Test
+    @DisplayName("[api] 댓글 리스트 조회")
+    void given_whenRequestingArticleComments_thenReturnsArticlesCommentJsonResponse() throws Exception {
+        //given
+
+        //when&then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @Test
+    @DisplayName("[api] 단건 댓글 조회")
+    void given_whenRequestingArticleComment_thenReturnsArticlesCommentJsonResponse() throws Exception {
+        //given
+
+        //when&then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스. 
해당 api 동작 여부만 확인하게끔 통합테스트 작성.